### PR TITLE
Assume inbound webhook if no user agent is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,6 +263,6 @@ module.exports.handler = (event, context, callback) => {
   let userAgent = event.headers['User-Agent']
 
   // A pretty hacky check to see if the message came from Slack
-  if (userAgent.indexOf('Slack') !== -1) return slackResponse(body, callback)
+  if (userAgent && userAgent.indexOf('Slack') !== -1) return slackResponse(body, callback)
   firemanQueueTaskResponse(body, callback)
 }


### PR DESCRIPTION
The new webhooks on the Clockwise side don't append a user agent by default.  I'd rather not jam some otherwise meaningless value into there since the same hooks go out to any configured customer.